### PR TITLE
Create Nav Drawer and Implement basic theme w/ screen placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,23 +114,27 @@
 
 - Protect Main Branch after this commit 😆 [X - 7/2/23]
 
-- Add Static code analysis [x - 7/16/23]
+- Add Static code analysis [X - 7/16/23]
 
-- Add Ktlint Pre-push git hook [x - 7/16/23]
+- Add Ktlint Pre-push git hook [X - 7/16/23]
 
-- Add CI/CD using Github Actions [x - 7/16/23]
+- Add CI/CD using Github Actions [X - 7/16/23]
 
-- Modify PR's to use Squash Merge w/ PR title as commit (to find PR by name and look through commits if needed) [x - 7/16/23]
+- Modify PR's to use Squash Merge w/ PR title as commit (to find PR by name and look through commits if needed) [X - 7/16/23]
 
-- Create Kanban board in Github Projects [x - 7/17/23]
+- Create Kanban board in Github Projects [X - 7/17/23]
 
 ## Development/Testing Stage:
 
-- Implement Basic Layout/Menu []
+- Create custom app icon [X - 7/25/23]
 
-- Implement Nav Functionality []
+- Create splash screen [X - 7/25/23]
 
-- Write Modules []
+- Implement Nav Functionality/Menu [X - 7/30/23]
+
+- Implement Basic Layouts []
+
+- Write custom LazyLayout for displaying weather badges []
 
 - Write Networking Code/Unit Tests []
 
@@ -143,6 +147,8 @@
 - Link Data to UI []
 
 ## QA Testing/Refining Stage:
+
+- Perform UX study with small group []
 
 - Profile/Fine Tune UI []
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,7 @@ dependencies {
 
     // Core
     implementation "androidx.core:core-ktx:$core_ktx_version"
+    implementation "com.google.android.material:material:$material_version"
     implementation "androidx.core:core-splashscreen:$splash_screen_version"
     implementation "androidx.test.ext:junit-ktx:$junit_androidx_ext_version"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <activity
             android:name=".ui.MainActivity"
             android:theme="@style/Theme.App.Starting"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/jHerscu/clearskies/ui/ClearSkiesApp.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/ClearSkiesApp.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -83,35 +85,12 @@ fun ClearSkiesApp(
 ) {
     Surface {
         val backStackState = navController.currentBackStackEntryAsState()
-        ModalNavigationDrawer( // TODO(jherscu): Disable drawer while onboarding experience is on/ add onboarding logic
+        AppNavDrawer(
             drawerState = drawerState,
-            drawerContent = {
-                ModalDrawerSheet(
-                    drawerContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    drawerTonalElevation = STANDARD_TONAL_ELEVATION_DP.dp
-                ) {
-                    val selectedColor = MaterialTheme.colorScheme.secondaryContainer
-                    Spacer(Modifier.height(NAV_DRAWER_TOP_PADDING_DP.dp))
-                    drawerItemsList.items.forEach { item ->
-                        NavigationDrawerItem(
-                            icon = { Icon(item.icon, contentDescription = null) },
-                            label = { Text(stringResource(id = item.screen.title)) },
-                            selected = item.screen.name == backStackState.value?.destination?.route,
-                            onClick = {
-                                scope.launch { drawerState.close() }
-                                navController.navigate(item.screen.name)
-                            },
-                            colors = NavigationDrawerItemDefaults.colors(
-                                unselectedContainerColor = Color.Transparent,
-                                selectedContainerColor = MaterialTheme.colorScheme.secondary,
-                                selectedIconColor = selectedColor,
-                                selectedTextColor = selectedColor
-                            ),
-                            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
-                        )
-                    }
-                }
-            }
+            drawerItemsList = drawerItemsList,
+            backStackState = backStackState,
+            scope = scope,
+            navController = navController
         ) {
             Surface(
                 color = MaterialTheme.colorScheme.primaryContainer,
@@ -145,6 +124,49 @@ fun ClearSkiesApp(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun AppNavDrawer(
+    drawerState: DrawerState,
+    drawerItemsList: DrawerItemsList,
+    backStackState: State<NavBackStackEntry?>,
+    scope: CoroutineScope,
+    navController: NavHostController,
+    content: @Composable () -> Unit
+) {
+    ModalNavigationDrawer( // TODO(jherscu): Disable drawer while onboarding experience is on/ add onboarding logic
+        drawerState = drawerState,
+        drawerContent = {
+            ModalDrawerSheet(
+                drawerContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                drawerTonalElevation = STANDARD_TONAL_ELEVATION_DP.dp
+            ) {
+                val selectedColor = MaterialTheme.colorScheme.secondaryContainer
+                Spacer(Modifier.height(NAV_DRAWER_TOP_PADDING_DP.dp))
+                drawerItemsList.items.forEach { item ->
+                    NavigationDrawerItem(
+                        icon = { Icon(item.icon, contentDescription = null) },
+                        label = { Text(stringResource(id = item.screen.title)) },
+                        selected = item.screen.name == backStackState.value?.destination?.route,
+                        onClick = {
+                            scope.launch { drawerState.close() }
+                            navController.navigate(item.screen.name)
+                        },
+                        colors = NavigationDrawerItemDefaults.colors(
+                            unselectedContainerColor = Color.Transparent,
+                            selectedContainerColor = MaterialTheme.colorScheme.secondary,
+                            selectedIconColor = selectedColor,
+                            selectedTextColor = selectedColor
+                        ),
+                        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                    )
+                }
+            }
+        }
+    ) {
+        content()
     }
 }
 

--- a/app/src/main/java/com/jHerscu/clearskies/ui/ClearSkiesApp.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/ClearSkiesApp.kt
@@ -2,39 +2,162 @@ package com.jHerscu.clearskies.ui
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.jHerscu.clearskies.R
+import com.jHerscu.clearskies.ui.theme.STANDARD_TONAL_ELEVATION_DP
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
-enum class Screens(@StringRes val title: Int) {
-    HOME(R.string.home_screen)
+private const val NAV_DRAWER_TOP_PADDING_DP = 36
+
+enum class Route(@StringRes val title: Int) {
+    HOME(R.string.home_screen),
+    LOCATIONS(R.string.locations_screen),
+    ADD_CITY(R.string.add_city_screen),
+    PREFERENCES(R.string.preferences_screen),
+    ONBOARDING(R.string.onboarding_screen)
 }
+
+data class DrawerItem(
+    val icon: ImageVector,
+    val screen: Route
+)
+
+@Immutable
+data class DrawerItemsList(val items: List<DrawerItem>)
 
 @Composable
 fun ClearSkiesApp(
     modifier: Modifier = Modifier,
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
+    drawerState: DrawerState = rememberDrawerState(initialValue = DrawerValue.Closed),
+    scope: CoroutineScope = rememberCoroutineScope(),
+    drawerItemsList: DrawerItemsList = DrawerItemsList(
+        listOf(
+            DrawerItem(
+                Icons.Default.Home,
+                Route.HOME
+            ),
+            DrawerItem(
+                Icons.Default.LocationOn,
+                Route.LOCATIONS
+            ),
+            DrawerItem(
+                Icons.Default.Edit,
+                Route.PREFERENCES
+            )
+        )
+    )
 ) {
-    NavHost(
-        modifier = modifier,
-        navController = navController,
-        startDestination = Screens.HOME.name
-    ) {
-        composable(Screens.HOME.name) {
-            Box( // TODO(jherscu): Rm test layout for real impl
-                modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center
+    Surface {
+        val backStackState = navController.currentBackStackEntryAsState()
+        ModalNavigationDrawer( // TODO(jherscu): Disable drawer while onboarding experience is on/ add onboarding logic
+            drawerState = drawerState,
+            drawerContent = {
+                ModalDrawerSheet(
+                    drawerContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    drawerTonalElevation = STANDARD_TONAL_ELEVATION_DP.dp
+                ) {
+                    val selectedColor = MaterialTheme.colorScheme.secondaryContainer
+                    Spacer(Modifier.height(NAV_DRAWER_TOP_PADDING_DP.dp))
+                    drawerItemsList.items.forEach { item ->
+                        NavigationDrawerItem(
+                            icon = { Icon(item.icon, contentDescription = null) },
+                            label = { Text(stringResource(id = item.screen.title)) },
+                            selected = item.screen.name == backStackState.value?.destination?.route,
+                            onClick = {
+                                scope.launch { drawerState.close() }
+                                navController.navigate(item.screen.name)
+                            },
+                            colors = NavigationDrawerItemDefaults.colors(
+                                unselectedContainerColor = Color.Transparent,
+                                selectedContainerColor = MaterialTheme.colorScheme.secondary,
+                                selectedIconColor = selectedColor,
+                                selectedTextColor = selectedColor
+                            ),
+                            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                        )
+                    }
+                }
+            }
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                tonalElevation = STANDARD_TONAL_ELEVATION_DP.dp
             ) {
-                Text(text = "ClearSkies Test Draw")
+                NavHost(
+                    modifier = modifier,
+                    navController = navController,
+                    startDestination = Route.HOME.name
+                ) {
+                    composable(Route.HOME.name) {
+                        TestScreen(title = "HOME")
+                    }
+                    composable(Route.LOCATIONS.name) {
+                        TestScreen(title = "LOCATIONS") // TODO(jherscu): create to track ime insets
+                        // TODO(jherscu): FAB should always be above system bars while rest of layout overlaps
+                    }
+                    composable(Route.ADD_CITY.name) {
+                        TestScreen(title = "ADD CITY") // TODO(jherscu): create to track ime insets
+                    }
+                    composable(Route.PREFERENCES.name) {
+                        TestScreen(title = "PREFERENCES")
+                    }
+                    composable(Route.ONBOARDING.name) {
+                        // TODO(jherscu): decide how to load api keys for both services
+                        // likely via some sort of webview experience coupled with drag and drop/copy and paste
+                        // possibly after first key is successfully loaded and a test ping is made with a 2xx response,
+                        // reload webview with new url for second service signup
+                        // Then tooltip exp could possibly be triggered in above standard screens
+                    }
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun TestScreen( // TODO(jherscu): Rm test layouts for real impl
+    title: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = title)
     }
 }

--- a/app/src/main/java/com/jHerscu/clearskies/ui/MainActivity.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.jHerscu.clearskies.ui
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,11 +18,20 @@ class MainActivity : ComponentActivity() {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
 
+        // Make app edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        val windowInsetsController =
+            WindowCompat.getInsetsController(this.window, this.window.decorView)
+
+        windowInsetsController.isAppearanceLightNavigationBars =
+            resources.configuration.uiMode != UI_MODE_NIGHT_YES
+        // Set splash screen to obey delay set in its vm
         splashScreen.setKeepOnScreenCondition { splashViewModel.isVisible.value }
 
         setContent {
-            AppTheme {
+            AppTheme(
+                dynamicColor = true // TODO(jherscu): Add pref for user to toggle on/off Dynamic Theming in app
+            ) {
                 ClearSkiesApp()
             }
         }

--- a/app/src/main/java/com/jHerscu/clearskies/ui/daily/DailyScreen.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/daily/DailyScreen.kt
@@ -1,1 +1,0 @@
-package com.jHerscu.clearskies.ui.daily

--- a/app/src/main/java/com/jHerscu/clearskies/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/home/HomeScreen.kt
@@ -1,0 +1,1 @@
+package com.jHerscu.clearskies.ui.home

--- a/app/src/main/java/com/jHerscu/clearskies/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/home/HomeViewModel.kt
@@ -1,4 +1,4 @@
-package com.jHerscu.clearskies.ui.daily
+package com.jHerscu.clearskies.ui.home
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -31,7 +31,7 @@ import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
-class DailyViewModel @Inject constructor(
+class HomeViewModel @Inject constructor(
     private val getCityByNameUseCase: GetCityByNameUseCase,
     private val weatherUseCases: WeatherUseCases,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher

--- a/app/src/main/java/com/jHerscu/clearskies/ui/hourly/HourlyScreen.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/hourly/HourlyScreen.kt
@@ -1,1 +1,0 @@
-package com.jHerscu.clearskies.ui.hourly

--- a/app/src/main/java/com/jHerscu/clearskies/ui/search/AddCityScreen.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/search/AddCityScreen.kt
@@ -1,0 +1,1 @@
+package com.jHerscu.clearskies.ui.search

--- a/app/src/main/java/com/jHerscu/clearskies/ui/search/AddCityViewModel.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/search/AddCityViewModel.kt
@@ -1,8 +1,8 @@
-package com.jHerscu.clearskies.ui.hourly
+package com.jHerscu.clearskies.ui.search
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class HourlyViewModel @Inject constructor() : ViewModel()
+class AddCityViewModel @Inject constructor() : ViewModel()

--- a/app/src/main/java/com/jHerscu/clearskies/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/theme/Dimens.kt
@@ -1,0 +1,3 @@
+package com.jHerscu.clearskies.ui.theme
+
+const val STANDARD_TONAL_ELEVATION_DP = 5

--- a/app/src/main/java/com/jHerscu/clearskies/ui/theme/Theme.kt
+++ b/app/src/main/java/com/jHerscu/clearskies/ui/theme/Theme.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -80,7 +79,7 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 @Composable
-fun AppTheme( // TODO(jherscu): Investigate why TopAppBar is showing different colors on different devices/Api levels
+fun AppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
@@ -99,8 +98,7 @@ fun AppTheme( // TODO(jherscu): Investigate why TopAppBar is showing different c
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="weather_is_old">Error. Weather wouldn\'t update.</string>
     <string name="weather_not_cached">Error. There is no saved weather for this city! Something went wrong.</string>
 
-    <!-- Screen Titles -->
+    <!-- Route Titles -->
     <string name="home_screen">Home</string>
+    <string name="locations_screen">Locations</string>
+    <string name="add_city_screen">Add City</string>
+    <string name="preferences_screen">Preferences</string>
+    <string name="onboarding_screen">App Setup</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,9 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.ClearSkies" parent="android:Theme.Material.Light.NoActionBar"/>
+    <style name="Theme.ClearSkies" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
         <item name="windowSplashScreenBackground">@color/splash_screen_bg</item>

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript { // TODO(jherscu): Update outdated buildscript syntax
         ktlint_compose_version = '0.0.26'
         leak_canary_version = '2.8.1'
         lifecycle_version = '2.6.1'
+        material_version = '1.9.0'
         mockk_version = '1.13.5'
         moshi_version = '1.9.3'
         nav_version = '2.6.0'


### PR DESCRIPTION
# Description

- Adds a ModalNavigationDrawer to steer navigation throughout the app
- Adds a NavHost to outline routes to the basic screens
- Creates the default theming experience and lays the groundwork to toggle dynamic theming on/off
- Provides room for an onboarding experience in the future

Closes #7

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigation has been tested, and the drawer selections reflect changes made to the back stack.

Also, the default theme shows in API level 30 and below, and dynamic theme shows in 31 and above.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
